### PR TITLE
fix: add primary_key to resource

### DIFF
--- a/src/datasync/nva/nva.py
+++ b/src/datasync/nva/nva.py
@@ -95,6 +95,7 @@ def nva(
             get_resources(client, institution_code),
             name="resources",
             write_disposition="replace",
+            primary_key="identifier",
             max_table_nesting=1,
         )
 


### PR DESCRIPTION
without it made a weird bug with some publications being duplicated, and others not being added