### PR TITLE
chg(biomark): change primary_key for tags for sling task

### DIFF
--- a/src/datasync/pit_registering_salmon.py
+++ b/src/datasync/pit_registering_salmon.py
@@ -481,7 +481,7 @@ def replicate(
     if tags and check_table_has_data(duckdb_path, "tags", dataset_name):
         stream_configs["tags"] = {
             "table_name": f"{dataset_name}.tags",
-            "primary_key": ["detected_at"],
+            "primary_key": ["detected_at", "tag"],
             "update_key": "detected_at",
             "time_column": "detected_at",
             "location": "antenna__reader__site__slug",


### PR DESCRIPTION
found a bug with the primary_key only being set to `detected_at` in the sling task for tags? this might be an issue if a fish is detected at the same time in different locations. the chances are slim, but you never know. added `tag` which is the ID for the tag, one fish can't be more than one place a time ;);)